### PR TITLE
[mg-3] Hotfix default app environment

### DIFF
--- a/backend/src/settings/__init__.py
+++ b/backend/src/settings/__init__.py
@@ -2,7 +2,7 @@ from os import environ
 
 from split_settings.tools import include, optional
 
-ENVIRONMENT = environ.get("APP_ENVIRONMENT", "development")
+ENVIRONMENT = environ.get("APP_ENVIRONMENT")
 
 assert ENVIRONMENT in ("development", "staging", "production")
 


### PR DESCRIPTION
## Changes:
* `development` is no longer default app environment in case `APP_ENVIRONMENT` is not set